### PR TITLE
User tracking types and matomo plugin updated.

### DIFF
--- a/repos/paella-user-tracking/changelog.md
+++ b/repos/paella-user-tracking/changelog.md
@@ -2,3 +2,4 @@
 
 - 2.2.3:
     * Changes in typescript types
+    * Update matomo plugin with last changes by the comunity

--- a/repos/paella-user-tracking/src/paella-user-tracking.d.ts
+++ b/repos/paella-user-tracking/src/paella-user-tracking.d.ts
@@ -30,6 +30,7 @@ declare module "@asicupv/paella-user-tracking" {
         cookieType?: string;        
         events?: Record<string, string>;
         customDimensions?: Record<string, string>;
+        disableAlwaysUseSendBeacon?: boolean;
     }
     
     export class MatomoUserTrackingDataPlugin<C extends MatomoUserTrackingDataPluginConfig = MatomoUserTrackingDataPluginConfig> extends DataPlugin<C, UserTrackingData> {}


### PR DESCRIPTION
* Added configuration settings for the URLs of the Matomo trackers.
* Use window._paq instead of a local reference of _paq.
* Send video title information for Matomo Media Analytics
* Add the option to disable the use of beacons for Matomo