### PR TITLE
Fixes user event tracking error when plugin var is not set

### DIFF
--- a/.changeset/strong-trams-cheer.md
+++ b/.changeset/strong-trams-cheer.md
@@ -1,0 +1,5 @@
+---
+"@asicupv/paella-user-tracking": patch
+---
+
+Fix userEventTracker error when plugin.name is not set

--- a/repos/paella-user-tracking/src/plugins/es.upv.paella.userEventTracker.ts
+++ b/repos/paella-user-tracking/src/plugins/es.upv.paella.userEventTracker.ts
@@ -73,7 +73,7 @@ export default class UserEventTrackerPlugin extends EventLogPlugin {
 				const { name, config } = params.plugin;
 				params.plugin = { name, config }
 			}
-			const trackingData = { event, params, plugin: params.plugin.name }
+			const trackingData = { event, params, plugin: params.plugin?.name || null }
 	
 			switch (event) {
 			case Events.SHOW_POPUP:


### PR DESCRIPTION
Some player events do not have plugin information attached, which leads to an error. This change checks whether the plugin information is set.

This PR helps fixing https://github.com/polimediaupv/paella-opencast/issues/158